### PR TITLE
Jenkinsfile -Switch back to sequential building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,26 +48,26 @@ pipeline {
     }
     
     stages {
-        stage('Build client & server') {
+        stage('Build client') {
             steps {
-                parallel(
-                    client: {
-                        container('node') {
-                            dir('client') {
-                                sh 'yarn  install'
-                            }
-                        }
-                    },
-                    server: {
-                        container('maven'){
-                            dir('server'){
-                                sh 'mvn clean verify -DskipTests --batch-mode package'
-                            }
-                        }
+                container('node') {
+                    dir('client') {
+                        sh 'yarn  install'
                     }
-                )
+                }
             }
         }
+
+        stage('Build server'){
+            steps{
+                container('maven'){
+                        dir('server'){
+                            sh 'mvn clean verify -DskipTests --batch-mode package'
+                        }
+                }
+            }
+        }
+        
 
          stage('Deploy client & server (master only)') {
             when { branch 'master'}


### PR DESCRIPTION
The parallel build seems to cause some issues and sometimes tries to execute commands in the wrong container. 
Switch back to sequential building to ensure for more stability