### PR TITLE
Use context menu from Sprotty

### DIFF
--- a/client/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/workflow/workflow-sprotty/src/di.config.ts
@@ -27,7 +27,7 @@ import {
     decorationModule,
     defaultGLSPModule,
     defaultModule,
-    DeleteContextMenuProviderRegistry,
+    DeleteContextMenuItemProvider,
     DiamondNodeView,
     edgeLayoutModule,
     editLabelFeature,
@@ -87,7 +87,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
     bind(GLSP_TYPES.IMovementRestrictor).to(NoCollisionMovementRestrictor).inSingletonScope();
     bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
-    bind(TYPES.IContextMenuItemProvider).to(DeleteContextMenuProviderRegistry);
+    bind(TYPES.IContextMenuItemProvider).to(DeleteContextMenuItemProvider);
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, 'graph', GLSPGraph, SGraphView);
     configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);

--- a/client/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/workflow/workflow-sprotty/src/di.config.ts
@@ -23,6 +23,7 @@ import {
     commandPaletteModule,
     configureModelElement,
     ConsoleLogger,
+    contextMenuModule,
     decorationModule,
     defaultGLSPModule,
     defaultModule,
@@ -86,7 +87,7 @@ const workflowDiagramModule = new ContainerModule((bind, unbind, isBound, rebind
     rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
     bind(GLSP_TYPES.IMovementRestrictor).to(NoCollisionMovementRestrictor).inSingletonScope();
     bind(TYPES.ICommandPaletteActionProvider).to(RevealNamedElementActionProvider);
-    bind(GLSP_TYPES.IContextMenuProvider).to(DeleteContextMenuProviderRegistry);
+    bind(TYPES.IContextMenuItemProvider).to(DeleteContextMenuProviderRegistry);
     const context = { bind, unbind, isBound, rebind };
     configureModelElement(context, 'graph', GLSPGraph, SGraphView);
     configureModelElement(context, 'task:automated', TaskNode, TaskNodeView);
@@ -114,7 +115,7 @@ export default function createContainer(widgetId: string): Container {
 
     container.load(decorationModule, validationModule, defaultModule, glspMouseToolModule, defaultGLSPModule, glspSelectModule, boundsModule, viewportModule,
         hoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule, labelEditModule, labelEditUiModule, glspEditLabelValidationModule,
-        workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule, glspContextMenuModule,
+        workflowDiagramModule, saveModule, executeCommandModule, toolFeedbackModule, modelHintsModule, contextMenuModule, glspContextMenuModule,
         commandPaletteModule, glspCommandPaletteModule, paletteModule, requestResponseModule, routingModule, edgeLayoutModule, zorderModule,
         layoutCommandsModule);
 

--- a/client/workflow/workflow-theia/src/browser/diagram/workflow-diagram-configuration.ts
+++ b/client/workflow/workflow-theia/src/browser/diagram/workflow-diagram-configuration.ts
@@ -18,12 +18,10 @@ import "sprotty-theia/css/theia-sprotty.css";
 import { createWorkflowDiagramContainer } from "@eclipse-glsp-examples/workflow-sprotty/lib";
 import { GLSP_TYPES, IActionDispatcher, registerDefaultTools, TYPES } from "@eclipse-glsp/client/lib";
 import { GLSPTheiaDiagramServer } from "@eclipse-glsp/theia-integration/lib/browser";
-import {
-    TheiaContextMenuService
-} from "@eclipse-glsp/theia-integration/lib/browser/diagram/glsp-theia-context-menu-service";
 import { SelectionService } from "@theia/core";
 import { Container, inject, injectable } from "inversify";
 import { DiagramConfiguration, TheiaDiagramServer, TheiaSprottySelectionForwarder } from "sprotty-theia/lib";
+import { TheiaContextMenuService } from "sprotty-theia/lib/sprotty/theia-sprotty-context-menu-service";
 
 import { WorkflowLanguage } from "../../common/workflow-language";
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10452,9 +10452,9 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sprotty-theia@next:
-  version "0.8.0-next.f8d72b4"
-  resolved "https://registry.yarnpkg.com/sprotty-theia/-/sprotty-theia-0.8.0-next.f8d72b4.tgz#7fd1946dfac517641b11ba29a5b683ba5d994db0"
-  integrity sha512-/YwyPBURlSP/K1yQDNVsVX6GxLm+cl6qptbywHOrh7BGQPfUT3VuGQ9RUx1EllTuI6u8mO8SP1j2fmfOJoMXvw==
+  version "0.8.0-next.fec87e7"
+  resolved "https://registry.yarnpkg.com/sprotty-theia/-/sprotty-theia-0.8.0-next.fec87e7.tgz#3c052822096097faa1e358883d437c41dc85d84d"
+  integrity sha512-3NGZNSWtBzyXy5PZza6IiSrEWpnqnmpHrUxb7Pe2qxm2M/Land0PvfQ334kMt7iQ+5c7kx/zpXFZs/3VKMglmQ==
   dependencies:
     "@theia/core" next
     "@theia/editor" next
@@ -10464,9 +10464,9 @@ sprotty-theia@next:
     sprotty next
 
 sprotty@next:
-  version "0.8.0-next.60603d1"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.8.0-next.60603d1.tgz#fd79c20691432d047f5a486c5882159786175a6a"
-  integrity sha512-lw+rhBTGhGPQMsS4LwElKuukFt9lrGmnhsEP9/t1EOzzloFcpCny5j50DtY0p4xWFwidfJL0BSataxdTKfuKAw==
+  version "0.8.0-next.78d7bc3"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.8.0-next.78d7bc3.tgz#af424cc0a01847a9e71e30af1f8a7e0876ecefe9"
+  integrity sha512-pgVng9NfGvoh4uAa8dkLxt2mE+8KdLdNGQjjaG6EEFwnq4mSDy5d32E0f+Dkke0g+erViBqD6GH9lhzylaHLiw==
   dependencies:
     autocompleter "5.1.0"
     file-saver "2.0.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10464,9 +10464,9 @@ sprotty-theia@next:
     sprotty next
 
 sprotty@next:
-  version "0.8.0-next.78d7bc3"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.8.0-next.78d7bc3.tgz#af424cc0a01847a9e71e30af1f8a7e0876ecefe9"
-  integrity sha512-pgVng9NfGvoh4uAa8dkLxt2mE+8KdLdNGQjjaG6EEFwnq4mSDy5d32E0f+Dkke0g+erViBqD6GH9lhzylaHLiw==
+  version "0.8.0-next.9533a22"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.8.0-next.9533a22.tgz#1ac8b2a52b2edf4b4b9edd28493f0470ecf06f44"
+  integrity sha512-90JhbavaipW4nOt0525bYb4AJ3EXK1VsEjrsNgVTRu0K6XrirgR8SsOlmhEepp7Wq+9bI/RgPMKwJFsSmJ7a/A==
   dependencies:
     autocompleter "5.1.0"
     file-saver "2.0.2"


### PR DESCRIPTION
Now since https://github.com/eclipse/sprotty/pull/144 is merged, we can remove the non-glsp-specific context menu code and re-use it from Sprotty.

Requires:
* https://github.com/eclipse-glsp/glsp-client/pull/24
* https://github.com/eclipse-glsp/glsp-theia-integration/pull/12