### PR TITLE
#87 Adapt workflow example to support readonly-mode

### DIFF
--- a/client/workflow/workflow-sprotty/src/di.config.ts
+++ b/client/workflow/workflow-sprotty/src/di.config.ts
@@ -20,7 +20,6 @@ import "sprotty/css/edit-label.css";
 import {
     boundsModule,
     buttonModule,
-    commandPaletteModule,
     configureModelElement,
     ConsoleLogger,
     defaultGLSPModule,
@@ -38,7 +37,7 @@ import {
     glspCommandPaletteModule,
     glspContextMenuModule,
     glspDecorationModule,
-    glspEditLabelValidationModule,
+    glspEditLabelModule,
     GLSPGraph,
     glspHoverModule,
     glspMouseToolModule,
@@ -47,7 +46,6 @@ import {
     GridSnapper,
     HtmlRoot,
     HtmlRootView,
-    labelEditModule,
     labelEditUiModule,
     layoutCommandsModule,
     LogLevel,
@@ -118,9 +116,9 @@ export default function createContainer(widgetId: string): Container {
     const container = new Container();
 
     container.load(validationModule, defaultModule, glspMouseToolModule, defaultGLSPModule, glspSelectModule, boundsModule, viewportModule, toolsModule,
-        glspHoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule, labelEditModule, labelEditUiModule, glspEditLabelValidationModule,
+        glspHoverModule, fadeModule, exportModule, expandModule, openModule, buttonModule, modelSourceModule, labelEditUiModule, glspEditLabelModule,
         workflowDiagramModule, executeCommandModule, toolFeedbackModule, modelHintsModule, glspContextMenuModule, glspServerCopyPasteModule,
-        commandPaletteModule, glspCommandPaletteModule, paletteModule, routingModule, glspDecorationModule, edgeLayoutModule, zorderModule,
+        glspCommandPaletteModule, paletteModule, routingModule, glspDecorationModule, edgeLayoutModule, zorderModule,
         layoutCommandsModule, directTaskEditor, navigationModule, markerNavigatorModule);
 
     overrideViewerOptions(container, {

--- a/client/workflow/workflow-theia/src/browser/diagram/workflow-diagram-readonly-view.ts
+++ b/client/workflow/workflow-theia/src/browser/diagram/workflow-diagram-readonly-view.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2020 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { EditMode } from "@eclipse-glsp/client";
+import { GLSPWidgetOpenerOptions } from "@eclipse-glsp/theia-integration/lib/browser";
+import {
+    Command,
+    CommandContribution,
+    CommandRegistry,
+    MenuContribution,
+    MenuModelRegistry,
+    SelectionService
+} from "@theia/core";
+import { OpenerService } from "@theia/core/lib/browser";
+import URI from "@theia/core/lib/common/uri";
+import { UriAwareCommandHandler } from "@theia/core/lib/common/uri-command-handler";
+import { NavigatorContextMenu } from "@theia/navigator/lib/browser/navigator-contribution";
+import { inject, injectable } from "inversify";
+
+export const OPEN_READONLY_DIAGRAM_VIEW: Command = {
+    id: "workflow.open.readonly",
+    label: "Open in Workflow Diagram Readonly View",
+    category: "2_additional",
+    iconClass: "fa fa-project-diagram"
+
+};
+@injectable()
+export class WorkflowDiagramReadonlyViewContribution implements CommandContribution, MenuContribution {
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
+    registerMenus(registry: MenuModelRegistry): void {
+        registry.registerMenuAction(NavigatorContextMenu.OPEN_WITH, {
+            commandId: OPEN_READONLY_DIAGRAM_VIEW.id,
+            label: "Workflow Diagram Readonly View",
+            icon: OPEN_READONLY_DIAGRAM_VIEW.iconClass
+        });
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(OPEN_READONLY_DIAGRAM_VIEW, new UriAwareCommandHandler(this.selectionService, {
+            execute: async (uri: URI) => {
+                const openerOptions: GLSPWidgetOpenerOptions = { editMode: EditMode.READONLY };
+                const opener = await this.openerService.getOpener(uri, openerOptions);
+                await opener.open(uri, openerOptions);
+            },
+            isVisible: (uri) => uri.toString().endsWith(".wf"),
+            isEnabled: (uri) => uri.toString().endsWith(".wf")
+        }));
+    }
+}

--- a/client/workflow/workflow-theia/src/browser/diagram/workflow-task-editing-context-menu.ts
+++ b/client/workflow/workflow-theia/src/browser/diagram/workflow-task-editing-context-menu.ts
@@ -32,7 +32,7 @@ export class WorkflowTaskEditCommandContribution implements CommandContribution 
         commands.registerCommand({ id: WorkflowTaskEditingCommands.EDIT_TASK, label: 'Direct Edit Task' },
             new GLSPCommandHandler(this.shell, {
                 actions: context => [new SetUIExtensionVisibilityAction(TaskEditor.ID, true, [context.selectedElements[0].id])],
-                isEnabled: context => context.selectedElements.filter(isTaskNode).length === 1
+                isEnabled: context => !context.isReadonly && context.selectedElements.filter(isTaskNode).length === 1
             })
         );
     }

--- a/client/workflow/workflow-theia/src/browser/frontend-module.ts
+++ b/client/workflow/workflow-theia/src/browser/frontend-module.ts
@@ -27,6 +27,7 @@ import { DiagramConfiguration } from "sprotty-theia";
 
 import { WorkflowDiagramConfiguration } from "./diagram/workflow-diagram-configuration";
 import { WorkflowDiagramManager } from "./diagram/workflow-diagram-manager";
+import { WorkflowDiagramReadonlyViewContribution } from "./diagram/workflow-diagram-readonly-view";
 import { WorkflowGLSPDiagramClient } from "./diagram/workflow-glsp-diagram-client";
 import {
     WorkflowDiagramKeybindingContext,
@@ -65,4 +66,9 @@ export default new ContainerModule((bind: interfaces.Bind) => {
 
     // Example for a command that navigates to an element in a diagram with a query resolved by the server
     bind(CommandContribution).to(ExampleNavigationCommandContribution).inSingletonScope();
+
+    // Readonly workflow diagram view
+    bind(WorkflowDiagramReadonlyViewContribution).toSelf().inSingletonScope();
+    bind(MenuContribution).toService(WorkflowDiagramReadonlyViewContribution);
+    bind(CommandContribution).toService(WorkflowDiagramReadonlyViewContribution);
 });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -805,7 +805,7 @@
     "@eclipse-glsp/client" next
     balloon-css "^0.5.0"
 
-"@eclipse-glsp/client@0.8.0-next.182b274", "@eclipse-glsp/client@next":
+"@eclipse-glsp/client@next":
   version "0.8.0-next.182b274"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.182b274.tgz#918509db7129fc0e9cfe3e72865e612bd58aff0b"
   integrity sha512-/FCLagJpQAy0zOVcZpON8NEDAix5KC9ADDuR7h78bz4WRFbcCWmvioS5wR3cQsbGcyyOJmk0VO2pA4LDAXxh5g==
@@ -815,7 +815,7 @@
     uuid "7.0.3"
     vscode-ws-jsonrpc "^0.0.2-1"
 
-"@eclipse-glsp/theia-integration@0.8.0-next.0b7d765":
+"@eclipse-glsp/theia-integration@next":
   version "0.8.0-next.0b7d765"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/theia-integration/-/theia-integration-0.8.0-next.0b7d765.tgz#2229a48532f5502249fd23453626775b57647598"
   integrity sha512-xKia8D2p16T/F9PdgLBT7jnQsaCziSN/9XMyqmDth8SIcl2dDTgtq9kO47e7wwNqewFJUU4ONrfHlIEgvIzs+g==

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -798,17 +798,17 @@
     to-fast-properties "^2.0.0"
 
 "@eclipse-glsp-examples/workflow-sprotty@next":
-  version "0.8.0-next.4b8fd101"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-sprotty/-/workflow-sprotty-0.8.0-next.4b8fd101.tgz#8deefaf27ab1f24acdfd78693d5237c01a9f0a9d"
-  integrity sha512-KvQKWI+KANm0sGPDLNJfdFx+sTWSKZVSkxKA/c685DBVzWtGAD+j5t3/BuSazLinvR0vs0YD/+CwuMeV6asY9g==
+  version "0.8.0-next.0bfbfb04"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-sprotty/-/workflow-sprotty-0.8.0-next.0bfbfb04.tgz#6c6b420117e0123a608693056634a736247b5b19"
+  integrity sha512-5GaiHnw4y53K+V2k3Lp+iutXrP3Tft4IObWk4zgYju5/7JhDvro02Tl6/WUN0iIfVe0jffT8VcuMixBraV1ZmQ==
   dependencies:
     "@eclipse-glsp/client" next
     balloon-css "^0.5.0"
 
 "@eclipse-glsp/client@next":
-  version "0.8.0-next.182b274"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.182b274.tgz#918509db7129fc0e9cfe3e72865e612bd58aff0b"
-  integrity sha512-/FCLagJpQAy0zOVcZpON8NEDAix5KC9ADDuR7h78bz4WRFbcCWmvioS5wR3cQsbGcyyOJmk0VO2pA4LDAXxh5g==
+  version "0.8.0-next.e555d60"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-next.e555d60.tgz#647cf27b3dc12efe248ef3307bac968eef17c0b8"
+  integrity sha512-EAwQ/rZk1yQ7o7cCxZ339SeRnS9A+vOjdXCD5YE67owketMUyr33GAuIlL/FXS3tCIVbBIC+K1DxySrB7A/0Jw==
   dependencies:
     autocompleter "5.1.0"
     sprotty next
@@ -816,9 +816,9 @@
     vscode-ws-jsonrpc "^0.0.2-1"
 
 "@eclipse-glsp/theia-integration@next":
-  version "0.8.0-next.0b7d765"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/theia-integration/-/theia-integration-0.8.0-next.0b7d765.tgz#2229a48532f5502249fd23453626775b57647598"
-  integrity sha512-xKia8D2p16T/F9PdgLBT7jnQsaCziSN/9XMyqmDth8SIcl2dDTgtq9kO47e7wwNqewFJUU4ONrfHlIEgvIzs+g==
+  version "0.8.0-next.4d0b27e"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/theia-integration/-/theia-integration-0.8.0-next.4d0b27e.tgz#ca1987cdc917d762db40861409575343b48c35c4"
+  integrity sha512-ud08SN/PbmRGBnOLerDaiKq9VSbtXI+v+JCSXZ00T3cBU3CPuf2ddIqHST5qSNe6LJW11+V7q4ufOXDma8qkog==
   dependencies:
     "@eclipse-glsp/client" next
     "@theia/core" "1.0.0"
@@ -1758,9 +1758,9 @@
     "@types/node" "*"
 
 "@wdio/cli@^6.0.14":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-6.3.0.tgz#91baf4f691d48832c6206ba77c7e402543ed4323"
-  integrity sha512-3OQjdenggHIarpIE/OvzWS9Hjc38derfBZaVOmMiK4+3StYfMt/QKEYawjSunfJXWouE8mkKow/4amdnuGtLPw==
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-6.3.3.tgz#59313cb4fabbaeb1adb2ec7e0867f4cc127ab463"
+  integrity sha512-WCfBgclhRBu4RQF0Low4zVPBovhduQPe5e1OnhgOzRHb+cYPNoFXszfDp4/J7cXcbxP/d0jYIyaWvmVnosv/Qg==
   dependencies:
     "@wdio/config" "6.1.14"
     "@wdio/logger" "6.0.16"
@@ -1777,7 +1777,7 @@
     lodash.union "^4.6.0"
     mkdirp "^1.0.4"
     recursive-readdir "^2.2.2"
-    webdriverio "6.3.0"
+    webdriverio "6.3.3"
     yargs "^15.0.1"
     yarn-install "^1.0.0"
 
@@ -1791,13 +1791,13 @@
     glob "^7.1.2"
 
 "@wdio/local-runner@^6.0.14":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@wdio/local-runner/-/local-runner-6.3.0.tgz#1359f21d12d5dd4d2d01075ff66f681b75cfd194"
-  integrity sha512-Ej6NDEWtVQ+20cuh1eAmYP3c8i/TiWYT5Pc8UQu/OLqb7W6ecSPg2swdwrQcsX7iU6DCuPAp6LAclNbARUNEUg==
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/@wdio/local-runner/-/local-runner-6.3.3.tgz#9c99d56f91b93d136ffd9ff80b2304db94fcc26c"
+  integrity sha512-InmfCZpVWuuZ2eIZ/oiROkmk0drqcGp6quRH8ZWEeLVsHbLcbSTrVtbBsgcRbHQ5P/znLficnNTWuGTuWGL21A==
   dependencies:
     "@wdio/logger" "6.0.16"
     "@wdio/repl" "6.3.0"
-    "@wdio/runner" "6.3.0"
+    "@wdio/runner" "6.3.3"
     async-exit-hook "^2.0.1"
     stream-buffers "^3.0.2"
 
@@ -1833,10 +1833,10 @@
   dependencies:
     "@wdio/utils" "6.3.0"
 
-"@wdio/runner@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@wdio/runner/-/runner-6.3.0.tgz#45baac186adea194204ec2fb05a5dc9146ef95a6"
-  integrity sha512-V4yqQPRG2bvlWw3tFW8rIJbPeavvQ/h8U9cj4lNVsPBOUYTd4/wRBYgJYIdAzu/2uqXOIslGXqEXov3mX475sA==
+"@wdio/runner@6.3.3":
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/@wdio/runner/-/runner-6.3.3.tgz#1672ffcde898d6dc5c3ea8c1c2433cbdb51a3511"
+  integrity sha512-2LfgFV86FakXFVTdT8y7TMCCduzjyNOsugvn2VoCyuViq4apAwpbC3MD9LQqcDMIVhU9NMSjgZC3acDetkWcJQ==
   dependencies:
     "@wdio/config" "6.1.14"
     "@wdio/logger" "6.0.16"
@@ -1844,7 +1844,7 @@
     deepmerge "^4.0.0"
     gaze "^1.1.2"
     webdriver "6.3.0"
-    webdriverio "6.3.0"
+    webdriverio "6.3.3"
 
 "@wdio/selenium-standalone-service@^6.0.12":
   version "6.1.14"
@@ -1857,9 +1857,9 @@
     selenium-standalone "^6.15.1"
 
 "@wdio/sync@^6.0.14":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@wdio/sync/-/sync-6.3.0.tgz#abe122ab3a6c1e50735e36c927f89763806707bc"
-  integrity sha512-PhDYERXoFWsb8F0VLcNovCat/L5ly7ACywEHi9RAykWpo9T16mFZe063LkwKXPKZCvYyDRMZZoJRGPENOm1odQ==
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/@wdio/sync/-/sync-6.3.3.tgz#87fefb571132b4b62c96a9f42ac44f9586c1e716"
+  integrity sha512-WNq+hhkgk9LluKLP2nQ/9+EH8HNQnROFFHvYuznxb1aKj/zhZvqWuQPpmMWhPMBSTpkdbdLCYerZWKcamYOcJQ==
   dependencies:
     "@types/puppeteer" "^3.0.1"
     "@wdio/logger" "6.0.16"
@@ -3766,14 +3766,14 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30001102"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001102.tgz#28e7da3f2969781728a0f50119a7aca179bf9e72"
-  integrity sha512-VUH/Ch7IaLSmugVKMTQEJlvSUAezLQY0uo1OZ6TJryWDln5vt/QrJjj+h/fVTuhUfYFc4pqfIc0u9ENn+vUy/g==
+  version "1.0.30001104"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001104.tgz#a8d68942c857435ad36a97486178d9d3c24e7b23"
+  integrity sha512-40cTUhuSN1p/zRMtTqxSZhp4aCFX4AuEwrWzSD4CRu+Zx/8Xe530zNs3wMGodaOE9A5PLP8XenrnVdBEcg8kAA==
 
 caniuse-lite@^1.0.30001093:
-  version "1.0.30001102"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001102.tgz#3275e7a8d09548f955f665e532df88de0b63741a"
-  integrity sha512-fOjqRmHjRXv1H1YD6QVLb96iKqnu17TjcLSaX64TwhGYed0P1E1CCWZ9OujbbK4Z/7zax7zAzvQidzdtjx8RcA==
+  version "1.0.30001104"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001104.tgz#4e3d5b3b1dd3c3529f10cb7f519c62ba3e579f5d"
+  integrity sha512-pkpCg7dmI/a7WcqM2yfdOiT4Xx5tzyoHAXWsX5/HxZ3TemwDZs0QXdqbE0UPLPVy/7BeK7693YfzfRYfu1YVpg==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -4026,9 +4026,9 @@ cli-spinners@^0.1.2:
   integrity sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=
 
 cli-spinners@^2.0.0, cli-spinners@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.3.0.tgz#0632239a4b5aa4c958610142c34bb7a651fc8df5"
-  integrity sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.4.0.tgz#c6256db216b878cfba4720e719cec7cf72685d7f"
+  integrity sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==
 
 cli-table@^0.3.1:
   version "0.3.1"
@@ -5140,10 +5140,10 @@ devtools-protocol@0.0.767361:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.767361.tgz#5977f2558b84f9df36f62501bdddb82f3ae7b66b"
   integrity sha512-ziRTdhEVQ9jEwedaUaXZ7kl9w9TF/7A3SXQ0XuqrJB+hMS62POHZUWTbumDN2ehRTfvWqTPc2Jw4gUl/jggmHA==
 
-devtools@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/devtools/-/devtools-6.3.0.tgz#46867a8d1a07854c41156479cc18fde61b83a07b"
-  integrity sha512-BvNacS/oQBQqMzdCshHCXG5p7nlVrUWlJ1BbUKSKgTrel64Jl031Pekag3UAsgtSeHU8/MOR/wom/eXPwRaynQ==
+devtools@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/devtools/-/devtools-6.3.3.tgz#4bc206e95026b27b64487f7e0e4afe5dc3adc91e"
+  integrity sha512-VHvJH7y2/pHtDzhXF8T9mlT5sqrUl2WSjCWhjvyohTyfMjtIu15p78lx3NowMwfo12N2/3riW9dVGeVOa6WILQ==
   dependencies:
     "@wdio/config" "6.1.14"
     "@wdio/logger" "6.0.16"
@@ -5329,9 +5329,9 @@ electron-rebuild@^1.8.6:
     yargs "^14.2.0"
 
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.488:
-  version "1.3.499"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.499.tgz#06949f19877dafa42915e57dfeb4c1cfb86a8649"
-  integrity sha512-y7FwtQm/8xuLMnYQfBQDYzCpNn+VkSnf4c3Km5TWMNXg7JA5RQBuxmcLaKdDVcIK0K5xGIa7TlxpRt4BdNxNoA==
+  version "1.3.501"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.501.tgz#faa17a2cb0105ee30d5e1ca87eae7d8e85dd3175"
+  integrity sha512-tyzuKaV2POw2mtqBBzQGNBojMZzH0MRu8bT8T/50x+hWeucyG/9pkgAATy+PcM2ySNM9+8eG2VllY9c6j4i+bg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -9516,9 +9516,9 @@ nanomatch@^1.2.9:
     to-regex "^3.0.1"
 
 native-request@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/native-request/-/native-request-1.0.5.tgz#da67637c0a0ed0758243d1a688d647612f2d5a0a"
-  integrity sha512-7wU3DvBGAJQxWuMR3F62zrhB7hxNj2DdlC/eBVrCgavc6+ZpFZOqS/PsR7QyUPLMkFk0GvvzoeeOAZGLLnObnA==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/native-request/-/native-request-1.0.7.tgz#ff742dc555b4c8f2f1c14b548639ba174e573856"
+  integrity sha512-9nRjinI9bmz+S7dgNtf4A70+/vPhnd+2krGpy4SUlADuOuSa24IDkNaZ+R/QT1wQ6S8jBdi6wE7fLekFZNfUpQ==
 
 ncp@~2.0.0:
   version "2.0.0"
@@ -10447,9 +10447,9 @@ popsicle@^9.0.0:
     tough-cookie "^2.0.0"
 
 portfinder@^1.0.13:
-  version "1.0.26"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.26.tgz#475658d56ca30bed72ac7f1378ed350bd1b64e70"
-  integrity sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.27.tgz#a41333c116b5e5f3d380f9745ac2f35084c4c758"
+  integrity sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==
   dependencies:
     async "^2.6.2"
     debug "^3.1.1"
@@ -13797,10 +13797,10 @@ webdriver@6.3.0:
     got "^11.0.2"
     lodash.merge "^4.6.1"
 
-webdriverio@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-6.3.0.tgz#73be4d45919681357b13f73038f516d954351699"
-  integrity sha512-XkyUUTLImAVY5QFerRLa81Vz7v8VrdTPxI2o51yL3+Emw1hWSTa/6nOGfJSjUhLgnRebOooOxgFEnGlLARXW0A==
+webdriverio@6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-6.3.3.tgz#edb46aaf42a92b64996f135b0e66ee4066c0ebac"
+  integrity sha512-/ahCs6sna4M+/GZ5RPh5LLTEzfh5+gJD0vOpmA4nmarpKjqnfuwtqTETjmQCfqKTjiLVwzqShnsAedbYuw9Q2g==
   dependencies:
     "@types/puppeteer" "^3.0.1"
     "@wdio/config" "6.1.14"
@@ -13810,7 +13810,7 @@ webdriverio@6.3.0:
     archiver "^4.0.1"
     atob "^2.1.2"
     css-value "^0.0.1"
-    devtools "6.3.0"
+    devtools "6.3.3"
     get-port "^5.1.1"
     grapheme-splitter "^1.0.2"
     lodash.clonedeep "^4.5.0"

--- a/server/org.eclipse.glsp.example.workflow/src/main/java/org/eclipse/glsp/example/workflow/model/WorkflowModelFactory.java
+++ b/server/org.eclipse.glsp.example.workflow/src/main/java/org/eclipse/glsp/example/workflow/model/WorkflowModelFactory.java
@@ -21,11 +21,11 @@ import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.api.utils.ServerMessageUtil;
 import org.eclipse.glsp.api.utils.ServerStatusUtil;
 import org.eclipse.glsp.graph.GModelRoot;
-import org.eclipse.glsp.server.model.FileBasedModelFactory;
+import org.eclipse.glsp.server.model.JsonFileModelFactory;
 
 import com.google.inject.Inject;
 
-public class WorkflowModelFactory extends FileBasedModelFactory {
+public class WorkflowModelFactory extends JsonFileModelFactory {
    @Inject
    private ActionProcessor actionProcessor;
 

--- a/server/org.eclipse.glsp.example.workflow/src/main/java/org/eclipse/glsp/example/workflow/provider/WorkflowCommandPaletteActionProvider.java
+++ b/server/org.eclipse.glsp.example.workflow/src/main/java/org/eclipse/glsp/example/workflow/provider/WorkflowCommandPaletteActionProvider.java
@@ -46,7 +46,9 @@ public class WorkflowCommandPaletteActionProvider implements CommandPaletteActio
    @SuppressWarnings("checkstyle:CyclomaticComplexity")
    public List<LabeledAction> getActions(final EditorContext editorContext, final GraphicalModelState modelState) {
       List<LabeledAction> actions = Lists.newArrayList();
-
+      if (modelState.isReadonly()) {
+         return actions;
+      }
       GModelIndex index = modelState.getIndex();
       List<String> selectedIds = editorContext.getSelectedElementIds();
       Optional<GPoint> lastMousePosition = editorContext.getLastMousePosition();

--- a/server/org.eclipse.glsp.example.workflow/src/main/java/org/eclipse/glsp/example/workflow/provider/WorkflowContextMenuItemProvider.java
+++ b/server/org.eclipse.glsp.example.workflow/src/main/java/org/eclipse/glsp/example/workflow/provider/WorkflowContextMenuItemProvider.java
@@ -19,6 +19,7 @@ import static org.eclipse.glsp.example.workflow.utils.ModelTypes.AUTOMATED_TASK;
 import static org.eclipse.glsp.example.workflow.utils.ModelTypes.MANUAL_TASK;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,9 @@ public class WorkflowContextMenuItemProvider implements ContextMenuItemProvider 
    public List<MenuItem> getItems(final List<String> selectedElementIds, final GPoint position,
       final Map<String, String> args,
       final GraphicalModelState modelState) {
+      if (modelState.isReadonly()) {
+         return Collections.emptyList();
+      }
       MenuItem newAutTask = new MenuItem("newAutoTask", "Automated Task",
          Arrays.asList(new CreateNodeOperation(AUTOMATED_TASK, position)), true);
       MenuItem newManTask = new MenuItem("newManualTask", "Manual Task",


### PR DESCRIPTION
- Disable context-menu/palette items if in readonly-mode
- Add "Workflow Diagram Readonly View" to "Open-with" menu

part of eclipse-glsp/glsp/issues/87