### PR TITLE
#60 #17 Fix maven build warnings and enable CI checkstyle

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+
+[*.{js,ts,md}]
+indent_size = 4
+
+[*.{json,yml}]
+indent_size = 2

--- a/minimal/client/browser-app/package.json
+++ b/minimal/client/browser-app/package.json
@@ -21,10 +21,11 @@
     "@theia/cli": "1.4.0"
   },
   "scripts": {
-    "prepare": "theia build --mode development",
+    "prepare": "yarn build",
+    "build": "theia build --mode development",
     "start": "theia start --MINIMAL_GLSP=5013 --root-dir=../workspace",
     "start:debug": "theia start --MINIMAL_GLSP=5013  --root-dir=../workspace --loglevel=debug --DEBUG",
-    "watch": "theia build --watch --mode development"
+    "watch": "yarn build --mode development"
   },
   "theia": {
     "target": "browser"

--- a/minimal/client/minimal-glsp/package.json
+++ b/minimal/client/minimal-glsp/package.json
@@ -3,11 +3,31 @@
   "version": "0.8.0",
   "description": "GLSP sprotty diagrams for the Minimal DSL",
   "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
-  "author": "Eclipse GLSP",
   "keywords": [
     "glsp",
     "minimal",
     "diagram"
+  ],
+  "author": {
+    "name": "Eclipse GLSP"
+  },
+  "homepage": "https://www.eclipse.org/glsp/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-glsp/glsp-examples.git"
+  },
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
+  "contributors": [
+    {
+      "name": "Tobias Ortmayr",
+      "email": "tortmayr@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
+    }
+  ],
+  "files": [
+    "lib",
+    "src",
+    "css"
   ],
   "dependencies": {
     "@eclipse-glsp/client": "0.8.1"
@@ -17,17 +37,12 @@
     "typescript": "3.9.2"
   },
   "scripts": {
-    "prepare": "yarn run clean && yarn run build",
+    "prepare": "yarn clean && yarn build && yarn lint",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run lint",
+    "build": "tsc",
     "lint": "eslint -c ./.eslintrc.js --ext .ts ./src",
     "watch": "tsc -w"
   },
-  "files": [
-    "lib",
-    "src",
-    "css"
-  ],
   "main": "lib/index",
   "types": "lib/index"
 }

--- a/minimal/client/minimal-theia/package.json
+++ b/minimal/client/minimal-theia/package.json
@@ -1,18 +1,31 @@
 {
   "name": "@eclipse-glsp-examples/minimal-theia",
   "version": "0.8.0",
-  "keywords": [
-    "theia-extension"
-  ],
   "description": "Theia extension for the Minimal GLSP example",
   "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
-  "files": [
-    "lib",
-    "src"
+  "keywords": [
+    "theia-extension"
   ],
   "author": {
     "name": "Eclipse GLSP"
   },
+  "homepage": "https://www.eclipse.org/glsp/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-glsp/glsp-examples.git"
+  },
+  "bugs": "https://github.com/eclipse-glsp/glsp/issues",
+  "contributors": [
+    {
+      "name": "Tobias Ortmayr",
+      "email": "tortmayr@eclipsesource.com",
+      "url": "https://www.eclipsesource.com"
+    }
+  ],
+  "files": [
+    "lib",
+    "src"
+  ],
   "dependencies": {
     "@eclipse-glsp-examples/minimal-glsp": "0.8.0",
     "@eclipse-glsp/theia-integration": "0.8.0",

--- a/minimal/client/package.json
+++ b/minimal/client/package.json
@@ -7,9 +7,11 @@
     "node": ">=10.19.0 <13"
   },
   "scripts": {
-    "test": "yarn",
+    "test": "lerna run test",
     "prepare": "lerna run prepare",
     "watch": "lerna run --parallel watch",
+    "build": "yarn install --ignore-scripts && lerna run build",
+    "lint": "lerna run lint --",
     "rebuild:browser": "theia rebuild:browser",
     "publish": "yarn && yarn publish:latest",
     "start:browser": "yarn rebuild:browser && cd browser-app && yarn start",
@@ -52,7 +54,6 @@
   "workspaces": [
     "minimal-glsp",
     "minimal-theia",
-    "browser-app",
-    "electron-app"
+    "browser-app"
   ]
 }

--- a/minimal/client/tslint.json
+++ b/minimal/client/tslint.json
@@ -1,8 +1,0 @@
-{
-  "//": [
-    "Lint rules expected to be used in interactive editors."
-  ],
-  "extends": [
-    "./configs/tslint.json"
-  ]
-}

--- a/minimal/server/org.eclipse.glsp.example.minimal/.checkstyle
+++ b/minimal/server/org.eclipse.glsp.example.minimal/.checkstyle
@@ -6,8 +6,14 @@
     <additional-data name="cache-file" value="true"/>
     <additional-data name="cache-file-location" value="EMFcloud Checkstyle_1618908540765_cache.xml"/>
   </local-check-config>
-  <fileset name="All Non-generated" enabled="true" check-config-name="EMF.cloud Checkstyle" local="true">
-    <file-match-pattern match-pattern=".java$" include-pattern="true"/>
-    <file-match-pattern match-pattern="src-gen" include-pattern="false"/>
+  <local-check-config name="maven-checkstyle-plugin default" location="jar:file:/home/tobias/.m2/repository/org/eclipse/emfcloud/org.eclipse.emfcloud.checkstyle/0.1.0-RC1/org.eclipse.emfcloud.checkstyle-0.1.0-RC1.jar!/emfcloud-checkstyle.xml" type="remote" description="maven-checkstyle-plugin configuration default">
+    <property name="checkstyle.header.file" value="/home/tobias/OpenSource/GLSP/eclipse-examples/.metadata/.plugins/org.eclipse.core.resources/.projects/org.eclipse.glsp.example.minimal/com.basistech.m2e.code.quality.checkstyleConfigurator/checkstyle-header-default.txt"/>
+    <property name="checkstyle.cache.file" value="${project_loc}/target/checkstyle-cachefile"/>
+  </local-check-config>
+  <fileset name="java-sources-default" enabled="true" check-config-name="maven-checkstyle-plugin default" local="true">
+    <file-match-pattern match-pattern="^src/main/java/.*\/.*\.java" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/main/java.*.*src-gen/.*\.java" include-pattern="false"/>
+    <file-match-pattern match-pattern="^src/main/resources.*\.properties" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/test/resources.*\.properties" include-pattern="true"/>
   </fileset>
 </fileset-config>

--- a/minimal/server/org.eclipse.glsp.example.minimal/pom.xml
+++ b/minimal/server/org.eclipse.glsp.example.minimal/pom.xml
@@ -47,6 +47,11 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.source>11</java.source>
+		<java.target>11</java.target>
+		<checkstyle>8.39</checkstyle>
+		<checkstyle.plugin>3.1.2</checkstyle.plugin>
+
 	</properties>
 
 	<dependencies>
@@ -63,8 +68,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${java.source}</source>
+					<target>${java.target}</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -94,18 +99,18 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>3.1.2</version>
+				<version>${checkstyle.plugin}</version>
 				<configuration>
 					<configLocation>emfcloud-checkstyle.xml</configLocation>
 					<consoleOutput>true</consoleOutput>
-					<sourceDirectories>src</sourceDirectories>
+					<excludes>**/src-gen/**/*.java</excludes>
 				</configuration>
 				<executions>
 					<execution>
+						<phase>validate</phase>
 						<goals>
 							<goal>check</goal>
 						</goals>
-						<phase>verify</phase>
 					</execution>
 				</executions>
 				<dependencies>
@@ -117,7 +122,7 @@
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>8.39</version>
+						<version>${checkstyle}</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -134,48 +139,8 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-dependency-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>copy-dependencies</id>
-								<phase>package</phase>
-								<goals>
-									<goal>copy-dependencies</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>${project.build.directory}/libs</outputDirectory>
-									<overWriteReleases>false</overWriteReleases>
-									<overWriteSnapshots>false</overWriteSnapshots>
-									<overWriteIfNewer>true</overWriteIfNewer>
-									<excludeTransitive>false</excludeTransitive>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>com.googlecode.addjars-maven-plugin</groupId>
-						<artifactId>addjars-maven-plugin</artifactId>
-						<version>1.0.5</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>add-jars</goal>
-								</goals>
-								<configuration>
-									<resources>
-										<resource>
-											<directory>${project.build.directory}/libs</directory>
-										</resource>
-									</resources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.0.0</version>
+						<version>3.2.4</version>
 						<configuration>
 							<transformers>
 								<transformer
@@ -191,8 +156,13 @@
 										<exclude>META-INF/*.SF</exclude>
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
+										<exclude>META-INF/LICENSE</exclude>
+										<exclude>META-INF/NOTICE</exclude>
+										<exclude>META-INF/DEPENDENCIES</exclude>
+										<exclude>META-INF/MANIFEST.MF</exclude>
 										<exclude>.options</exclude>
 										<exclude>.api_description</exclude>
+										<exclude>plugin.properties</exclude>
 										<exclude>*.profile</exclude>
 										<exclude>*.html</exclude>
 										<exclude>about.*</exclude>


### PR DESCRIPTION
Server
- Rework fatjar generation to get rid of warnings related to overlapping classes.

Client
- Update metadata
- Refactor build & lint scripts
- Remove tslint remains

Jenkinsfile:
- Use new slim `eclipseglsp:alpine` image
- Add code style reporting and publishing
- Add reporting for maven and java errors

Part of eclipse-glsp/glsp/issues/60
Part of eclipse-glsp/glsp/issues/17