### PR TITLE
GLSP-973 Fix Eclipse project template for Windows

### DIFF
--- a/project-templates/java-emf-eclipse/glsp-server/org.eclipse.glsp.example.javaemf.editor/META-INF/MANIFEST.MF
+++ b/project-templates/java-emf-eclipse/glsp-server/org.eclipse.glsp.example.javaemf.editor/META-INF/MANIFEST.MF
@@ -21,10 +21,13 @@ Require-Bundle: org.eclipse.elk.alg.common;bundle-version="0.5.0",
  org.eclipse.glsp.example.javaemf.server;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.glsp.server.emf;bundle-version="[1.0.0,2.0.0]",
  com.google.inject,
- org.eclipse.glsp.ide.editor;bundle-version="[1.0.0,2.0.0)"
+ org.eclipse.glsp.ide.editor;bundle-version="[1.0.0,2.0.0)",
+ org.eclipse.ui.ide,
+ org.eclipse.core.resources
 Bundle-ClassPath: .
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.glsp.example.javaemf.editor.Activator
 Bundle-Vendor: Eclipse GLSP
 Import-Package: javax.servlet
+Export-Package: org.eclipse.glsp.example.javaemf.editor

--- a/project-templates/java-emf-eclipse/glsp-server/org.eclipse.glsp.example.javaemf.editor/plugin.xml
+++ b/project-templates/java-emf-eclipse/glsp-server/org.eclipse.glsp.example.javaemf.editor/plugin.xml
@@ -12,7 +12,7 @@
    <extension
          point="org.eclipse.ui.editors">
       <editor
-            class="org.eclipse.glsp.ide.editor.ui.GLSPDiagramEditor"
+            class="org.eclipse.glsp.example.javaemf.editor.TaskListEditor"
             contributorClass="org.eclipse.glsp.ide.editor.ui.GLSPDiagramEditorActionContributor"
             default="true"
             extensions="tasklist"

--- a/project-templates/java-emf-eclipse/glsp-server/org.eclipse.glsp.example.javaemf.editor/src/org/eclipse/glsp/example/javaemf/editor/TaskListEditor.java
+++ b/project-templates/java-emf-eclipse/glsp-server/org.eclipse.glsp.example.javaemf.editor/src/org/eclipse/glsp/example/javaemf/editor/TaskListEditor.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.glsp.example.javaemf.editor;
+
+import org.eclipse.glsp.ide.editor.ui.FocusAwareBrowser;
+import org.eclipse.glsp.ide.editor.ui.GLSPDiagramEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+
+public class TaskListEditor extends GLSPDiagramEditor {
+
+   @Override
+   protected Browser createBrowser(final Composite parent) {
+      Browser browser = new FocusAwareBrowser(parent, SWT.NO_SCROLL | SWT.EDGE);
+      browser.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
+      toDispose.add(browser::dispose);
+      return browser;
+   }
+}


### PR DESCRIPTION
Temporary workaround to fix the java-emf-eclipse project template under Windows. Can be removed after the upcoming 2.0 Release