### PR TITLE
GLSP1100: Fix IPv4/v6 connection problems

### DIFF
--- a/project-templates/java-emf-eclipse/glsp-client/.vscode/settings.json
+++ b/project-templates/java-emf-eclipse/glsp-client/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.fixAll.eslint": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/project-templates/java-emf-theia/glsp-client/.vscode/settings.json
+++ b/project-templates/java-emf-theia/glsp-client/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.fixAll.eslint": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/project-templates/java-emf-theia/glsp-client/tasklist-theia/src/node/glsp-server-contribution.ts
+++ b/project-templates/java-emf-theia/glsp-client/tasklist-theia/src/node/glsp-server-contribution.ts
@@ -35,7 +35,8 @@ export class TaskListGLSPServerContribution extends GLSPSocketServerContribution
             executable: JAR_FILE,
             additionalArgs: ['--consoleLog', 'false', '--fileLog', 'true', '--logDir', LOG_DIR],
             socketConnectionOptions: {
-                port: getPort(PORT_ARG_KEY, DEFAULT_PORT)
+                port: getPort(PORT_ARG_KEY, DEFAULT_PORT),
+                host: '127.0.0.1'
             }
         };
     }

--- a/project-templates/java-emf-theia/java-emf-theia-example.code-workspace
+++ b/project-templates/java-emf-theia/java-emf-theia-example.code-workspace
@@ -17,7 +17,6 @@
             "source.fixAll.eslint": true
         },
         "eslint.validate": ["javascript", "typescript"],
-        "prettier.prettierPath": "workflow/client/node_modules/prettier",
         "search.exclude": {
             "**/node_modules": true,
             "**/lib": true

--- a/project-templates/node-json-theia/glsp-client/.vscode/settings.json
+++ b/project-templates/node-json-theia/glsp-client/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.fixAll.eslint": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/project-templates/node-json-theia/glsp-server/.vscode/settings.json
+++ b/project-templates/node-json-theia/glsp-server/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.organizeImports": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/project-templates/node-json-theia/node-json-theia.code-workspace
+++ b/project-templates/node-json-theia/node-json-theia.code-workspace
@@ -14,7 +14,6 @@
             "source.fixAll.eslint": true
         },
         "eslint.validate": ["javascript", "typescript"],
-        "prettier.prettierPath": "project-templates/glsp-client/node_modules/prettier",
         "search.exclude": {
             "**/node_modules": true,
             "**/lib": true

--- a/project-templates/node-json-vscode/glsp-client/.vscode/settings.json
+++ b/project-templates/node-json-vscode/glsp-client/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.fixAll.eslint": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/project-templates/node-json-vscode/glsp-client/tasklist-vscode/extension/src/tasklist-extension.ts
+++ b/project-templates/node-json-vscode/glsp-client/tasklist-vscode/extension/src/tasklist-extension.ts
@@ -33,7 +33,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (process.env.TASKLIST_SERVER_DEBUG !== 'true') {
         const serverProcess = new GlspServerLauncher({
             executable: path.join(__dirname, '../../../../glsp-server/lib/index.js'),
-            socketConnectionOptions: { port: JSON.parse(process.env.TASKLIST_SERVER_PORT || DEFAULT_SERVER_PORT) },
+            socketConnectionOptions: { port: JSON.parse(process.env.TASKLIST_SERVER_PORT || DEFAULT_SERVER_PORT), host: '127.0.0.1' },
             additionalArgs: ['--no-consoleLog', '--fileLog', '--logDir', path.join(__dirname, '../../../../glsp-server/bundle/')],
             logging: true,
             serverType: 'node'

--- a/project-templates/node-json-vscode/glsp-server/.vscode/settings.json
+++ b/project-templates/node-json-vscode/glsp-server/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.organizeImports": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/project-templates/node-json-vscode/node-json-vscode.code-workspace
+++ b/project-templates/node-json-vscode/node-json-vscode.code-workspace
@@ -14,7 +14,6 @@
             "source.fixAll.eslint": true
         },
         "eslint.validate": ["javascript", "typescript"],
-        "prettier.prettierPath": "project-templates/glsp-client/node_modules/prettier",
         "search.exclude": {
             "**/node_modules": true,
             "**/lib": true

--- a/workflow/glsp-client/.vscode/settings.json
+++ b/workflow/glsp-client/.vscode/settings.json
@@ -10,7 +10,6 @@
     "source.fixAll.eslint": true
   },
   "eslint.validate": ["javascript", "typescript"],
-  "prettier.prettierPath": "node_modules/prettier",
   "search.exclude": {
     "**/node_modules": true,
     "**/lib": true

--- a/workflow/glsp-client/workflow-theia/src/node/workflow-glsp-server-contribution.ts
+++ b/workflow/glsp-client/workflow-theia/src/node/workflow-glsp-server-contribution.ts
@@ -35,7 +35,8 @@ export class WorkflowGLServerContribution extends GLSPSocketServerContribution {
             executable: JAR_FILE,
             additionalArgs: ['--consoleLog', 'false', '--fileLog', 'true', '--logDir', LOG_DIR],
             socketConnectionOptions: {
-                port: getPort(PORT_ARG_KEY, DEFAULT_PORT)
+                port: getPort(PORT_ARG_KEY, DEFAULT_PORT),
+                host: '127.0.0.1'
             }
         };
     }

--- a/workflow/workflow-example.code-workspace
+++ b/workflow/workflow-example.code-workspace
@@ -17,7 +17,6 @@
             "source.fixAll.eslint": true
         },
         "eslint.validate": ["javascript", "typescript"],
-        "prettier.prettierPath": "workflow/client/node_modules/prettier",
         "search.exclude": {
             "**/node_modules": true,
             "**/lib": true


### PR DESCRIPTION
Explicitly set the host in connection options to `127.0.0.1` to avoid ipv4/ipv6 connection issues. Fix prettier config issue
https://github.com/eclipse-glsp/glsp/issues/1100